### PR TITLE
redesigned file stream source task to handle large file  ( > 100MB)

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
@@ -37,13 +37,17 @@ import java.util.Map;
 public class FileStreamSourceConnector extends SourceConnector {
     public static final String TOPIC_CONFIG = "topic";
     public static final String FILE_CONFIG = "file";
+    public static final String BUFFER_SIZE = "buffer.size";
+    private static final int DEFAULT_BUFFER_SIZE = 4096;
 
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
         .define(FILE_CONFIG, Type.STRING, Importance.HIGH, "Source filename.")
-        .define(TOPIC_CONFIG, Type.STRING, Importance.HIGH, "The topic to publish data to");
+        .define(TOPIC_CONFIG, Type.STRING, Importance.HIGH, "The topic to publish data to")
+        .define(BUFFER_SIZE, Type.INT, DEFAULT_BUFFER_SIZE, Importance.HIGH, "The max buffer size to keep in memory");
 
     private String filename;
     private String topic;
+    private String bufferSize;
 
     @Override
     public String version() {
@@ -58,6 +62,9 @@ public class FileStreamSourceConnector extends SourceConnector {
             throw new ConnectException("FileStreamSourceConnector configuration must include 'topic' setting");
         if (topic.contains(","))
             throw new ConnectException("FileStreamSourceConnector should only have a single topic when used as a source.");
+        bufferSize = props.get(BUFFER_SIZE);
+        if(bufferSize == null || bufferSize.isEmpty())
+            bufferSize = String.valueOf(DEFAULT_BUFFER_SIZE);
     }
 
     @Override
@@ -73,6 +80,7 @@ public class FileStreamSourceConnector extends SourceConnector {
         if (filename != null)
             config.put(FILE_CONFIG, filename);
         config.put(TOPIC_CONFIG, topic);
+        config.put(BUFFER_SIZE, bufferSize);
         configs.add(config);
         return configs;
     }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -35,6 +35,7 @@ public class FileStreamSourceConnectorTest {
     private static final String SINGLE_TOPIC = "test";
     private static final String MULTIPLE_TOPICS = "test1,test2";
     private static final String FILENAME = "/somefilename";
+    private static final int BUFFER_SIZE = 4096;
 
     private FileStreamSourceConnector connector;
     private ConnectorContext ctx;
@@ -49,6 +50,7 @@ public class FileStreamSourceConnectorTest {
         sourceProperties = new HashMap<>();
         sourceProperties.put(FileStreamSourceConnector.TOPIC_CONFIG, SINGLE_TOPIC);
         sourceProperties.put(FileStreamSourceConnector.FILE_CONFIG, FILENAME);
+        sourceProperties.put(FileStreamSourceConnector.BUFFER_SIZE, String.valueOf(BUFFER_SIZE));
     }
 
     @Test
@@ -62,6 +64,8 @@ public class FileStreamSourceConnectorTest {
                 taskConfigs.get(0).get(FileStreamSourceConnector.FILE_CONFIG));
         assertEquals(SINGLE_TOPIC,
                 taskConfigs.get(0).get(FileStreamSourceConnector.TOPIC_CONFIG));
+        assertEquals(String.valueOf(BUFFER_SIZE),
+                taskConfigs.get(0).get(FileStreamSourceConnector.BUFFER_SIZE));
 
         // Should be able to return fewer than requested #
         taskConfigs = connector.taskConfigs(2);
@@ -70,6 +74,8 @@ public class FileStreamSourceConnectorTest {
                 taskConfigs.get(0).get(FileStreamSourceConnector.FILE_CONFIG));
         assertEquals(SINGLE_TOPIC,
                 taskConfigs.get(0).get(FileStreamSourceConnector.TOPIC_CONFIG));
+        assertEquals(String.valueOf(BUFFER_SIZE),
+                taskConfigs.get(0).get(FileStreamSourceConnector.BUFFER_SIZE));
 
         PowerMock.verifyAll();
     }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 public class FileStreamSourceTaskTest {
 
     private static final String TOPIC = "test";
+    private static final int BUFFER_SIZE = 4096;
 
     private File tempFile;
     private Map<String, String> config;
@@ -55,6 +56,7 @@ public class FileStreamSourceTaskTest {
         config = new HashMap<>();
         config.put(FileStreamSourceConnector.FILE_CONFIG, tempFile.getAbsolutePath());
         config.put(FileStreamSourceConnector.TOPIC_CONFIG, TOPIC);
+        config.put(FileStreamSourceConnector.BUFFER_SIZE, String.valueOf(BUFFER_SIZE));
         task = new FileStreamSourceTask();
         offsetStorageReader = PowerMock.createMock(OffsetStorageReader.class);
         context = PowerMock.createMock(SourceTaskContext.class);


### PR DESCRIPTION
**Problem:**

File stream source task was failing for large files (> 100MB) with OOM exception. 

**Reason**

File stream source task keeps on reading data until the last line is read and store the same in memory resulting into OOM exception, if the file is large.

**Solution**

File stream source task now reads only limited number of bytes from a file in a single poll call. The number of bytes to read is configurable via property `buffer.size`. 